### PR TITLE
Fix Bluesky link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -61,7 +61,7 @@
         <p>You can follow us on 
             <ul>
                 <li><a href="https://www.linkedin.com/company/pycon-uk">LinkedIn</a></li>
-                <li><a href="https://bsky.app/profile/pyconuk.bsky.social">Bluesky (@pyconuk.pyconuk.org)</a></li>
+                <li><a href="https://bsky.app/profile/pyconuk.org">Bluesky (@pyconuk.org)</a></li>
                 <li><a href="https://fosstodon.org/@PyConUK">Mastodon (@PyConUK@fosstodon.org)</a></li>
                 <li><a href="https://twitter.com/pyconuk">Twitter (@PyConUK)</a></li>
             </ul>


### PR DESCRIPTION
https://bsky.app/profile/pyconuk.org not https://bsky.app/profile/pyconuk.bsky.social

(I don't know why Bluesky doesn't forward these)