### PR TITLE
Avoid unconfirmed sponsorship and other details.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,7 @@ title: "PyCon UK 2025"
 # Flags for when things™ happen
 cfp_open: false
 cfp_closed: false
+spons_prosp_avail: false
 tickets_open: false
 schedule_ready: false
 show_sponsors: false

--- a/src/schedule.md
+++ b/src/schedule.md
@@ -14,7 +14,7 @@ title: Schedule
 {% else %}
 <p>The conference will be made up of 3 days of talks and workshops from Friday - Sunday and a single day of sprints on Monday. All ticket holders are entitled to join the sprints day at no additional charge.</p>
 
-<p>We will be holding a Young Coder’s day on {{ site.young_coders_date }} suitable for young people aged from about 8 years old to 16 years old. Young Coder’s tickets are available at £6 for a young coder and an accompanying adult. The adult will accompany and be responsible for their young coder for the duration of the day.</p>
+<p>We will be holding a Young Coder’s day on {{ site.young_coders_date }} suitable for young people aged from about 8 years old to 16 years old. Young Coder’s tickets are available at £TBD for a young coder and an accompanying adult. The adult will accompany and be responsible for their young coder for the duration of the day.</p>
 {% if site.show_django_girls %}
 <p>We will also be holding a Django Girls workshop on {{ site.django_girls_date }}. This workshop will have its own application process which we will update here shortly. It will not be a general access workshop within the the broader conference programme.</p>
 {% endif %}

--- a/src/sponsorship.md
+++ b/src/sponsorship.md
@@ -20,9 +20,12 @@ If you are interested in sponsoring the conference, please [contact us](/contact
 {% else %}
 
 **Sponsoring PyCon UK is a great way for your company to support the Python
-community, promote your comany and meet Python experiences Python developers.**
+community, promote your company and meet Python developers.**
 
-More information, incuding a sponsorship prospectus, ***coming soon***.
+If you are interested in sponsoring the conference, please contact {{
+"pyconuk@uk.python.org" | create_mailto_link }}.
+
+More information, including a sponsorship prospectus ***coming soon***.
 
 {% endif %}
 

--- a/src/sponsorship.md
+++ b/src/sponsorship.md
@@ -3,18 +3,28 @@ layout: default
 title: Sponsorship
 ---
 
-**Sponsoring PyCon UK is a great way for your company to support the Python community, promote your products to more than seven hundred delegates, and meet Python developers who are looking for work.**
+{% if site.schedule_ready == true %}
+
+**Sponsoring PyCon UK is a great way for your company to support the Python community, promote your products to several hundred delegates, and meet Python developers who are looking for work.**
 
 We couldn't run the conference without the generous support of our sponsors.
 
 In return, we will ensure that your company is given exposure before, during, and after the conference, and we will work with you so that you get exactly what you're looking for out of sponsoring the conference.
 
 If you are interested in sponsoring the conference, please [contact us](/contact/).
-[Full details of our sponsorship packages are now available.](/sponsor-prospectus/)
 
 [Practical information for sponsors](/information-for-sponsors/)
 
 [Sponsorship prospectus](/sponsor-prospectus/)
+
+{% else %}
+
+**Sponsoring PyCon UK is a great way for your company to support the Python
+community, promote your comany and meet Python experiences Python developers.**
+
+More information, incuding a sponsorship prospectus, ***coming soon***.
+
+{% endif %}
 
 <figure>
   <img

--- a/src/sponsorship.md
+++ b/src/sponsorship.md
@@ -3,7 +3,7 @@ layout: default
 title: Sponsorship
 ---
 
-{% if site.schedule_ready == true %}
+{% if site. spons_prosp_avail == true %}
 
 **Sponsoring PyCon UK is a great way for your company to support the Python community, promote your products to several hundred delegates, and meet Python developers who are looking for work.**
 
@@ -23,7 +23,7 @@ If you are interested in sponsoring the conference, please [contact us](/contact
 community, promote your company and meet Python developers.**
 
 If you are interested in sponsoring the conference, please contact {{
-"pyconuk@uk.python.org" | create_mailto_link }}.
+"sponsorship@uk.python.org" | create_mailto_link }}.
 
 More information, including a sponsorship prospectus ***coming soon***.
 


### PR DESCRIPTION
Made the main (now only) sponsorship page more generic with details 'coming soon'.

Made Young Coders ticket price TBD.