### PR TITLE
Show django girls page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ spons_prosp_avail: true
 tickets_open: true
 schedule_ready: false
 show_sponsors: false
-show_django_girls: false
+show_django_girls: true
 
 # When changing the year, please change it in the title, above. We can't use vars in vars.
 con_year: 2025

--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,7 @@ tickets_open: true
 schedule_ready: false
 show_sponsors: false
 show_django_girls: true
+django_girls_applications_open: false
 
 # When changing the year, please change it in the title, above. We can't use vars in vars.
 con_year: 2025

--- a/src/django-girls.md
+++ b/src/django-girls.md
@@ -51,6 +51,12 @@ title: Django Girls
   <img src="/images/django_girls_assist.jpg" alt="Another one of the django girls being assisted- you're not alone.">
 </figure>
 
-<a href="https://djangogirls.org/pyconuk/">Apply to attend Django Girls at PyCon UK {{ site.con_year }}</a>
+<a href="https://djangogirls.org/pyconuk/">
+{% if site.django_girls_applications_open == true %}
+Apply to attend Django Girls at PyCon UK {{ site.con_year }}
+{% else %}
+More about Django Girls at PyCon UK {{ site.con_year }}
+{% endif %}
+</a>
 
 {% endif %}


### PR DESCRIPTION
The django girls website is now ready, so link to it!

Applications are not open yet though, so change the wording of the website link.
When applications open, we should change the wording back.
Hence, add a toggle in the config called `django_girls_applications_open` that we can use to change the wording.