### PR TITLE
Change 'CONTACT' to 'Contact Theatre'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,7 @@ cfp_end: Sunday 11th May 2025
 django_girls_date: Saturday 20th September
 young_coders_date: Saturday 20th September
 
-con_location: CONTACT Manchester
+con_location: Contact Theatre, Manchester
 con_director: Becky Smith
 
 con_vat_number: GB431251341

--- a/src/_data/links.yaml
+++ b/src/_data/links.yaml
@@ -20,7 +20,7 @@ md:
     mastodon: "[Mastodon (@PyConUK@fosstodon.org)](https://fosstodon.org/@PyConUK)"
     twitter: "[X(Twitter) (@PyConUK)](https://twitter.com/pyconuk)"
 
-    contactmcr: "[CONTACT](https://contactmcr.com)"
+    contactmcr: "[Contact Theatre](https://contactmcr.com)"
 
   short:
     bluesky: "[Bluesky](https://bsky.app/profile/pyconuk.org)"
@@ -29,7 +29,7 @@ md:
     mastodon: "[Mastodon](https://fosstodon.org/@PyConUK)"
     twitter: "[X(Twitter)](https://twitter.com/pyconuk)"
 
-    contactmcr: "[CONTACT](https://contactmcr.com)"
+    contactmcr: "[Contact Theatre](https://contactmcr.com)"
 
 html:
   long:
@@ -38,7 +38,7 @@ html:
     mastodon: '<a href="https://fosstodon.org/@PyConUK">Mastodon (@PyConUK@fosstodon.org)</a>'
     twitter: '<a href="https://twitter.com/pyconuk">X(Twitter) (@PyConUK)</a>'
 
-    contactmcr: '<a href="https://contactmcr.com">CONTACT</a>'
+    contactmcr: '<a href="https://contactmcr.com">Contact Theatre</a>'
 
   short:
     bluesky: '<a href="https://bsky.app/profile/pyconuk.org">Bluesky</a>'
@@ -46,4 +46,4 @@ html:
     mastodon: '<a href="https://fosstodon.org/@PyConUK">Mastodon</a>'
     twitter: '<a href="https://twitter.com/pyconuk">X(Twitter)</a>'
 
-    contactmcr: '<a href="https://contactmcr.com">CONTACT</a>'
+    contactmcr: '<a href="https://contactmcr.com">Contact Theatre</a>'


### PR DESCRIPTION
I've put my reasoning for this idea in my commit message. tl;dr – I think it's less confusing/easier to Google, and the theatre do go by Contact Theatre as well.

I wanted to keep it separate from the work I'm doing to pull together local Manchester info. Which is on its way…