### PR TITLE
Add list of hotels to Venue page

### DIFF
--- a/src/venue.md
+++ b/src/venue.md
@@ -13,7 +13,7 @@ The site has accessible toilets, baby changing facilities, a lift to all floors,
 
 Parking isn't generally available, but parking for disabled visitors can be arranged in advance (see below).
 
-## Disabled parking
+### Disabled parking
 
 If you'd like access to disabled parking at the venue, please email <hires@contactmcr.com> to arrange it in advance. In your email, please mention:
 
@@ -21,3 +21,66 @@ If you'd like access to disabled parking at the venue, please email <hires@conta
 - the dates that you'll need to be able to park
 - your vehicle type and registration number
 - the driver's name
+
+## Accommodation
+
+Before choosing a place to stay, it's worth bearing in mind how far it is from the venue and (if you think you might go) to the city centre.
+
+Most places are walkable from the venue if you don't mind a 20-30 minute walk, but you can also use taxis, buses, or hop on a "Beryl bike" (Manchester's bike hire scheme).
+
+### Hotels
+
+There are a couple of hotels just over a 10 minute walk from the venue:
+
+- [Travelodge (Upper Brook Street)] is a [12 minute walk][travelodge map] to the east of the venue. While it's nearby, note that if you'd like to venture into the city centre during your stay that it's not quite so well located. For those arriving by train, it's a 30 minute walk from Manchester Piccadilly station.
+
+- [Hyatt Regency] (4 star, so more expensive) is [a similar distance away][hyatt map] from the venue, but is closer to the city. It's a 20 minute walk from Piccadilly station.
+
+[Travelodge (Upper Brook Street)]: https://www.travelodge.co.uk/hotels/523/Manchester-Upper-Brook-Street-hotel
+[travelodge map]: https://maps.app.goo.gl/Ki1GoXWb5GoNyFs27
+
+[Hyatt Regency]: https://www.hyatt.com/hyatt-regency/en-US/manrm-hyatt-regency-manchester
+[hyatt map]: https://maps.app.goo.gl/ce3tMJUhjvQ9DqPo7
+
+You've got more choice if you opt for a hotel close to the city centre. These are a 20-25 minute walk from the venue and about 10 minutes from Piccadilly station:
+
+- [ibis Manchester Centre] on Portland Street ([map][ibis map])
+- [Holiday Inn Express] on Oxford Road ([map][holiday inn map])
+- [Premier Inn Manchester Centre] on Portland Street ([map][premier map])
+- [Maldron Manchester City Centre] on Charles Street ([map][maldron map])
+- [Pendulum Hotel] on Sackville Street ([map][pendulum map])
+- [Wilde Aparthotels] on Dickinson St ([map][wilde map])
+
+[ibis Manchester Centre]: https://all.accor.com/hotel/3142/index.en.shtml
+[ibis map]: https://maps.app.goo.gl/FzotGwNGVbhabk2T9
+
+[Holiday Inn Express]: https://www.ihg.com/holidayinnexpress/hotels/gb/en/manchester/mchor/hoteldetail
+[holiday inn map]: https://maps.app.goo.gl/Eibai4ZM4bbLfCyP7
+
+[Premier Inn Manchester Centre]: https://www.premierinn.com/gb/en/hotels/england/greater-manchester/manchester/manchester-city-centre-portland-street.html
+[premier map]: https://maps.app.goo.gl/hXBAP2u8dxQ5XnZu8
+
+[Maldron Manchester City Centre]: https://www.maldronhotels.com/manchester-city-centre/
+[maldron map]: https://maps.app.goo.gl/Z16forXNhmFckSxo6
+
+[Pendulum Hotel]: https://www.pendulumhotel.co.uk/
+[pendulum map]: https://maps.app.goo.gl/T28F4S3wzXkdSSNw6
+
+[Wilde Aparthotels]: https://www.wilde.com/manchester/city-centre
+[wilde map]: https://maps.app.goo.gl/pHjc3VT8dPR3jJ8o8
+
+There are a lot of other choices if none of those take your fancy. This [list of hotels] will give you some more ideas (the most expensive ones are at the top, with a budget-friendly section further down the page).
+
+[list of hotels]: https://oxfordroadcorridor.com/place/where-to-stay-around-oxford-road/
+
+### Hostels
+
+The [Manchester YHA] is in a nice location. It's a 40 minute walk to the venue, 20 minutes to Oxford Road station, 30 minutes to Piccadilly station, and 35 minutes to Victoria station.
+
+The [Malacuna Hostel] (previously known as [Hilton Chambers]) is also worth considering. It's on the edge of Manchester's [Northern Quarter], which is where you'll find an eclectic mix of shops, plenty of bars, and lots of restaurants (it can be quite lively in the evenings). It's on the far side of the city centre from the venue, so a 40 minute walk away (or 10 minutes on a Beryl bike). But it's only an 11 minute walk to Piccadilly station, or 12 minutes to Victoria station.
+
+[Manchester YHA]: https://www.yha.org.uk/hostel/yha-manchester
+[Malacuna Hostel]: https://www.smartrental.com/en/malacuna/manchester/
+[Hilton Chambers]: https://maps.app.goo.gl/C5uXMdBcdpzUfUHm8
+
+[Northern Quarter]: https://www.visitmanchester.com/things-to-see-and-do/explore/neighbourhoods/northern-quarter/

--- a/src/venue.md
+++ b/src/venue.md
@@ -7,7 +7,7 @@ title: Venue
 
 This year's conference is being held at {{ links.contactmcr }} in Manchester.
 
-Our venue is in a central location close to Manchester University, with good [public transport links](https://contactmcr.com/visit/getting-here) close by.
+Our venue is on the south side of the city, close to Manchester University, with good [public transport links](https://contactmcr.com/visit/getting-here) close by.
 
 The site has accessible toilets, baby changing facilities, a lift to all floors, and great coffee.
 


### PR DESCRIPTION
I'm not sure whether hotels and instructions on how to travel to Manchester would be best on the Venue page, or on a new page titled Local Information or perhaps About Manchester.

However, I've realised that all the things I'll be writing up will be useful to people under two different circumstances:

1. Before the conference
2. When they're in Manchester

I think keeping "before" and "during" separate will be a useful thing. And I'm wondering if most of the people who are interested in looking at the Venue page are really going to be wondering how to get there.

So in the absence of a wider discussion on this subject, the direction I'm currently heading in is to make several pull requests addressing the different kind of local info. I'll add useful things before you arrive on the Venue page, with stuff about pubs, coffee shops, how to use the bus/hire a bike etc on a new page.

Please comment if this sounds daft/odd/we should talk about it!
