### PR TITLE
Update PSF link in Code of Conduct

### DIFF
--- a/src/code-of-conduct.md
+++ b/src/code-of-conduct.md
@@ -49,7 +49,7 @@ Your concern will be heard in confidence, taken seriously, and dealt with accord
 Conference staff - volunteers and organisers - will be on hand throughout the conference. Any concern, whatever it is, will be immediately passed on to a member of the conference committee. The committee will investigate promptly and if necessary will take appropriate action. This could include:
 
 *   asking a violator of the Code of Conduct to leave the event immediately (no refunds will be forthcoming)
-*   passing on details of the incident to the [Python Software Foundation](https://web.archive.org/web/20150607144447/https://www.python.org/psf)
+*   passing on details of the incident to the [Python Software Foundation](https://www.python.org/psf-landing/)
 *   informing the police about the incident
 
 We will provide you with a written statement of the outcome, whatever it is.


### PR DESCRIPTION
Spotted while reading the Code of Conduct. I’m assuming this wasn’t done intentionally? Doesn’t seem useful in this context to link to a page from 2015.